### PR TITLE
ueventd: fix jpeg3 permission

### DIFF
--- a/rootdir/ueventd.kitakami.rc
+++ b/rootdir/ueventd.kitakami.rc
@@ -45,6 +45,7 @@
 /dev/jpeg0                0660   system     camera
 /dev/jpeg1                0660   system     camera
 /dev/jpeg2                0660   system     camera
+/dev/jpeg3                0660   system     camera
 /dev/adsprpc-smd          0664   system     system
 /dev/system_health_monitor 0640  radio      system
 /dev/msm_rotator          0660   system     system


### PR DESCRIPTION
since jpeg_dma was fixed in kernel we can use it
if we have the needed permissions

Signed-off-by: Alin Jerpelea alin.jerpelea@sonymobile.com
